### PR TITLE
Accommodate file structure change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>datatables-tools</artifactId>
-    <version>2.2.5-SNAPSHOT</version>
+    <version>2.2.4-1-SNAPSHOT</version>
 
     <name>datatables-tools</name>
     <description>WebJar for DataTables Tools</description>
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>datatables</artifactId>
-            <version>1.10.6</version>
+            <version>1.10.7</version>
         </dependency>
     </dependencies>
     
@@ -96,10 +96,10 @@
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
                                     <fileset dir="${project.build.directory}/TableTools-${upstream.tag}">
-                                        <include name="media/js/**" />
-                                        <include name="media/css/*" />
-                                        <include name="media/images/*.png" />
-                                        <include name="media/swf/*.swf" />
+                                        <include name="js/**" />
+                                        <include name="css/*" />
+                                        <include name="images/*.png" />
+                                        <include name="swf/*.swf" />
                                     </fileset>
                                 </move>
                             </target>


### PR DESCRIPTION
The file structure changed after RELEASE_2_1_5 and there is no longer a /media folder. The /js, /css, /images, and /swf folders are at the root of the archive distribution instead of in /media.
